### PR TITLE
Add Error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Default options:
 	data: 'src/data/**/*.{json,yml}',
 	docs: 'src/docs/**/*.md',
 	helpers: {},
+	logErrors: false,
+	onError: function(error) {},
 	dest: 'dist'
 }
 ```
@@ -147,6 +149,20 @@ helpers: {
 	}
 }
 ```
+
+### options.logErrors
+
+Type: `Boolean`
+Default: `false`
+
+Whether or not to log errors to console. If set to false, the app will exit on error.
+
+### options.onError
+
+Type: `Function`
+Default: `null`
+
+Error handler function. Receives an `error` object param.
 
 ### options.dest
 

--- a/index.js
+++ b/index.js
@@ -154,18 +154,9 @@ var getFileName = function (filePath) {
  * @return {Object}
  */
 var getMatter = function (file) {
-	try {
-		return matter.read(file, {
-			parser: require('js-yaml').safeLoad
-		});
-	} catch (e) {
-		handleError({
-			name: e.name,
-			reason: e.reason,
-			message: e.message,
-			file: file
-		});
-	}
+	return matter.read(file, {
+		parser: require('js-yaml').safeLoad
+	});
 };
 
 
@@ -183,7 +174,6 @@ var handleError = function (e) {
 		name: 'Error',
 		reason: '',
 		message: 'An error occurred',
-		file: ''
 	}, e);
 
 	// call onError
@@ -194,7 +184,7 @@ var handleError = function (e) {
 
 	// log errors
 	if (options.logErrors) {
-		console.error(chalk.bold.red('Error (fabricator-assemble): [' + e.file + '] ' + e.message));
+		console.error(chalk.bold.red('Error (fabricator-assemble): ' + e.message));
 		exit = false;
 	}
 
@@ -600,6 +590,8 @@ module.exports = function (options) {
 		// assemble
 		assemble();
 
-	} catch(e) {}
+	} catch(e) {
+		handleError(e);
+	}
 
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "sort-object": "^1.0.0"
   },
   "devDependencies": {
+    "chalk": "^1.0.0",
     "del": "^1.1.1",
     "helper-markdown": "^0.1.1",
     "mocha": "^2.1.0"

--- a/test/test.js
+++ b/test/test.js
@@ -18,7 +18,8 @@ describe('fabricator-assemble', function () {
 		dest: './test/output',
 		helpers: {
 			markdown: require('helper-markdown')
-		}
+		},
+		logErrors: true
 	};
 
 	beforeEach(function () {


### PR DESCRIPTION
Adds basic logging options for YAML and Handlebars parsing errors. Introduces two new options: `logErrors` and `onError` (detailed below).

One big thing to note is that this introduces new default behavior of exiting the app with an error status if a compilation error is encountered. **Thoughts on this? Should the default be to just fail silently?** Looking for input.

**logErrors**: `{Boolean}`

Simple log to console

**onError**:  `{Function}`

Handler that allows users to hook into error events and handle them however they want.