### PR TITLE
Add `materialKey` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,13 @@ Default options:
 	layoutIncludes: 'src/views/layouts/includes/*',
 	views: ['src/views/**/*', '!src/views/+(layouts)/**'],
 	materials: 'src/materials/**/*',
-	materialKey: 'materials',
 	data: 'src/data/**/*.{json,yml}',
 	docs: 'src/docs/**/*.md',
+	keys: {
+		materials: 'materials',
+		views: 'views',
+		docs: 'docs'
+	}
 	helpers: {},
 	logErrors: false,
 	onError: function(error) {},
@@ -121,15 +125,6 @@ Default: `src/materials/**/*`
 
 Files to use a partials/helpers. These are the materials that make up your toolkit. by default, Fabricator comes with "components" and "structures", but you can define your own taxonomy.
 
-### options.materialKey
-
-Type: `String` 
-Default: `materials`
-
-Object keyword for accessing "materials" in a view templating context. Fabricator uses the term "materials" to describe what are really "partials" in Handelbars' terms. This allows you to use a term other than `materials` when accessing partials. 
-
-Note that this will also change the built-in `{{material <foo>}}` helper to use the singular form of whatever is defined. e.g. `materialKey: 'patterns'` -> `{{pattern <foo>}}`
-
 ### options.data
 
 Type: `String` or `Array`  
@@ -143,6 +138,38 @@ Type: `String` or `Array`
 Default: `src/docs/**/*.md`
 
 Markdown files containing toolkit-wide documentation
+
+### options.keys
+
+Type: `Objects` 
+Default: `materials/views/docs`
+
+Object keywords for accessing "materials", "views", and "docs" in a view templating context. Fabricator uses some specific terms like "materials" to describe what are really "partials" in Handelbars. This option give you the flexibility to define your own terms for `materials`, `views`, and `docs`.
+
+For example:
+
+```
+assemble({
+	keys: {
+		materials: 'patterns'
+	}
+});
+``` 
+
+```
+<!-- formerly `{{#each materials}}` -->
+{{#each patterns}}
+
+	<h1>{{name}}</h1>
+
+	{{#each items}}
+		<h2>{{name}}</h2>
+	{{/each}}
+
+{{/each}}
+```
+
+**Note**: this will also change the built-in `{{material <foo>}}` helper to use the **singular** form of whatever is defined for the `materials` key. e.g. `materialKey: 'patterns'` -> `{{pattern <foo>}}`. If you set a new key for `materials`, you will also need to update the `f-item-content.html` include to use the new helper name.
 
 ### options.helpers
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Default options:
 	layoutIncludes: 'src/views/layouts/includes/*',
 	views: ['src/views/**/*', '!src/views/+(layouts)/**'],
 	materials: 'src/materials/**/*',
+	materialKey: 'materials',
 	data: 'src/data/**/*.{json,yml}',
 	docs: 'src/docs/**/*.md',
 	helpers: {},
@@ -119,6 +120,15 @@ Type: `String` or `Array`
 Default: `src/materials/**/*`
 
 Files to use a partials/helpers. These are the materials that make up your toolkit. by default, Fabricator comes with "components" and "structures", but you can define your own taxonomy.
+
+### options.materialKey
+
+Type: `String` 
+Default: `materials`
+
+Object keyword for accessing "materials" in a view templating context. Fabricator uses the term "materials" to describe what are really "partials" in Handelbars' terms. This allows you to use a term other than `materials` when accessing partials. 
+
+Note that this will also change the built-in `{{material <foo>}}` helper to use the singular form of whatever is defined. e.g. `materialKey: 'patterns'` -> `{{pattern <foo>}}`
 
 ### options.data
 

--- a/index.js
+++ b/index.js
@@ -50,12 +50,6 @@ var defaults = {
 	materials: 'src/materials/**/*',
 
 	/**
-	 * Keyword used to access materials in views
-	 * @type {String}
-	 */
-	materialKey: 'materials',
-
-	/**
 	 * JSON or YAML data models that are piped into views
 	 * @type {(String|Array)}
 	 */
@@ -66,6 +60,16 @@ var defaults = {
 	 * @type {(String|Array)}
 	 */
 	docs: 'src/docs/**/*.md',
+
+	/**
+	 * Keywords used to access items in views
+	 * @type {Object}
+	 */
+	keys: {
+		materials: 'materials',
+		views: 'views',
+		docs: 'docs'
+	},
 
 	/**
 	 * Location to write files
@@ -211,11 +215,17 @@ var handleError = function (e) {
  */
 var buildContext = function (data) {
 
-	// set materialsKey to whatever is defined
-	var materialsObj = {};
-	materialsObj[options.materialKey] = assembly.materials;
+	// set keys to whatever is defined
+	var materials = {};
+	materials[options.keys.materials] = assembly.materials;
 
-	return _.assign({}, data, assembly.data, assembly.materialData, materialsObj, { views: assembly.views }, { docs: assembly.docs });
+	var views = {};
+	views[options.keys.views] = assembly.views;
+
+	var docs = {};
+	docs[options.keys.docs] = assembly.docs;
+
+	return _.assign({}, data, assembly.data, assembly.materialData, materials, views, docs);
 
 };
 
@@ -511,11 +521,11 @@ var registerHelpers = function () {
 	 * `material`
 	 * @description Like a normal partial include (`{{> partialName }}`),
 	 * but with some additional templating logic to help with nested block iterations.
-	 * The name of the helper is the singular form of whatever is defined as the `materialKey`
+	 * The name of the helper is the singular form of whatever is defined as the `options.keys.materials`
 	 * @example
 	 * {{material name context}}
 	 */
-	Handlebars.registerHelper(inflect.singularize(options.materialKey), function (name, context) {
+	Handlebars.registerHelper(inflect.singularize(options.keys.materials), function (name, context) {
 
 		var template = Handlebars.partials[name],
 			fn;
@@ -541,7 +551,7 @@ var registerHelpers = function () {
 var setup = function (userOptions) {
 
 	// merge user options with defaults
-	options = _.assign({}, defaults, userOptions);
+	options = _.merge({}, defaults, userOptions);
 
 	// set handlebars compile options
 	options.handlebars = (options.logErrors || _.isFunction(options.onError)) ? { strict: true } : {};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gray-matter": "^1.2.6",
     "handlebars": "^2.0.0",
     "html-minifier": "^0.6.9",
+    "i": "^0.3.3",
     "js-beautify": "^1.5.5",
     "js-yaml": "^3.2.7",
     "lodash": "^3.8.0",

--- a/test/expected/material-key.html
+++ b/test/expected/material-key.html
@@ -25,6 +25,11 @@
 
 		<h2>Form</h2>
 
+
+	<h1>Pages</h1>
+
+		<h2>Home</h2>
+
 	<script src="assets/scripts/main.js"></script>
 
 </body>

--- a/test/expected/material-key.html
+++ b/test/expected/material-key.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+
+	<meta charset="utf-8">
+	<meta http-equiv="x-ua-compatible" content="ie=edge">
+
+	<title>Document Name</title>
+
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<link rel="stylesheet" href="assets/styles/main.css">
+
+</head>
+<body>
+
+	<h1>Components</h1>
+
+		<h2>Alerts</h2>
+		<h2>Button</h2>
+		<h2>Toggles</h2>
+
+
+	<h1>Structures</h1>
+
+		<h2>Form</h2>
+
+	<script src="assets/scripts/main.js"></script>
+
+</body>
+</html>

--- a/test/fixtures/views/material-key.html
+++ b/test/fixtures/views/material-key.html
@@ -1,0 +1,13 @@
+---
+title: Document Name
+---
+
+{{#each patterns}}
+
+	<h1>{{name}}</h1>
+
+	{{#each items}}
+		<h2>{{name}}</h2>
+	{{/each}}
+
+{{/each}}

--- a/test/fixtures/views/material-key.html
+++ b/test/fixtures/views/material-key.html
@@ -11,3 +11,13 @@ title: Document Name
 	{{/each}}
 
 {{/each}}
+
+{{#each views}}
+
+	<h1>{{name}}</h1>
+
+	{{#each items}}
+		<h2>{{name}}</h2>
+	{{/each}}
+
+{{/each}}

--- a/test/test.js
+++ b/test/test.js
@@ -95,7 +95,11 @@ describe('fabricator-assemble', function () {
 
 	it('should use a custom material key', function (done) {
 
-		assemble(_.assign({}, options, { materialKey: 'patterns' }));
+		assemble(_.assign({}, options, {
+			keys: {
+				materials: 'patterns'
+			}
+		}));
 
 		var output = minify(fs.readFileSync('./test/output/material-key.html', 'utf-8'), { collapseWhitespace: true });
 		var expected = minify(fs.readFileSync('./test/expected/material-key.html', 'utf-8'), { collapseWhitespace: true });

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var assert = require('assert');
 var assemble = require('../');
 var del = require('del');
@@ -86,6 +87,18 @@ describe('fabricator-assemble', function () {
 
 		var output = minify(fs.readFileSync('./test/output/helpers.html', 'utf-8'), { collapseWhitespace: true });
 		var expected = minify(fs.readFileSync('./test/expected/helpers.html', 'utf-8'), { collapseWhitespace: true });
+
+		assert.equal(output, expected);
+		done();
+
+	});
+
+	it('should use a custom material key', function (done) {
+
+		assemble(_.assign({}, options, { materialKey: 'patterns' }));
+
+		var output = minify(fs.readFileSync('./test/output/material-key.html', 'utf-8'), { collapseWhitespace: true });
+		var expected = minify(fs.readFileSync('./test/expected/material-key.html', 'utf-8'), { collapseWhitespace: true });
 
 		assert.equal(output, expected);
 		done();


### PR DESCRIPTION
Add the `materialKey` option that allows users to define a keyword other than `materials` for accessing materials in a template.

e.g.

```
assemble({
  materialKey: `patterns`
});
```

```html
{{#each patterns}}

	<h1>{{name}}</h1>

	{{#each items}}
		<h2>{{name}}</h2>
	{{/each}}

{{/each}}
```
