### PR TITLE
make a `toTitleCase` option that preserves dots

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 // modules
 var _ = require('lodash');
 var beautifyHtml = require('js-beautify').html;
-var changeCase = require('change-case');
 var fs = require('fs');
 var globby = require('globby');
 var Handlebars = require('handlebars');
@@ -148,6 +147,17 @@ var buildContext = function (data) {
 
 
 /**
+ * Convert a file name to title case
+ * @param  {String} str
+ * @return {String}
+ */
+var toTitleCase = function(str) {
+    return str.replace(/(\-|_)/g, ' ').replace(/\w\S*/g, function(word) {
+        return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
+    });
+};
+
+/**
  * Insert the page into a layout
  * @param  {String} page
  * @param  {String} layout
@@ -184,12 +194,12 @@ var parseMaterials = function () {
 
 		if (!isSubCollection) {
 			assembly.materials[collection] = assembly.materials[collection] || {
-				name: changeCase.titleCase(collection),
+				name: toTitleCase(collection),
 				items: {}
 			};
 		} else {
 			assembly.materials[parent].items[collection] = assembly.materials[parent].items[collection] || {
-				name: changeCase.titleCase(collection),
+				name: toTitleCase(collection),
 				items: {}
 			};
 		}
@@ -217,12 +227,12 @@ var parseMaterials = function () {
 		// capture meta data for the material
 		if (!isSubCollection) {
 			assembly.materials[collection].items[id] = {
-				name: changeCase.titleCase(id),
+				name: toTitleCase(id),
 				notes: (fileMatter.data.notes) ? md.render(fileMatter.data.notes) : ''
 			};
 		} else {
 			assembly.materials[parent].items[collection].items[id] = {
-				name: changeCase.titleCase(id.split('.')[1]),
+				name: toTitleCase(id.split('.')[1]),
 				notes: (fileMatter.data.notes) ? md.render(fileMatter.data.notes) : ''
 			};
 		}
@@ -280,7 +290,7 @@ var parseDocs = function () {
 
 		// save each as unique prop
 		assembly.docs[id] = {
-			name: changeCase.titleCase(id),
+			name: toTitleCase(id),
 			content: md.render(fs.readFileSync(file, 'utf-8'))
 		};
 
@@ -376,13 +386,13 @@ var parseViews = function () {
 
 			// create collection if it doesn't exist
 			assembly.views[collection] = assembly.views[collection] || {
-				name: changeCase.titleCase(collection),
+				name: toTitleCase(collection),
 				items: {}
 			};
 
 			// store view data
 			assembly.views[collection].items[id] = {
-				name: changeCase.titleCase(id),
+				name: toTitleCase(id),
 				data: fileData
 			};
 

--- a/package.json
+++ b/package.json
@@ -17,14 +17,13 @@
   "license": "MIT",
   "repository": "fbrctr/fabricator-assemble",
   "dependencies": {
-    "change-case": "^2.2.0",
     "globby": "^1.2.0",
     "gray-matter": "^1.2.6",
     "handlebars": "^2.0.0",
     "html-minifier": "^0.6.9",
     "js-beautify": "^1.5.5",
     "js-yaml": "^3.2.7",
-    "lodash": "^2.4.1",
+    "lodash": "^3.8.0",
     "markdown-it": "^3.1.0",
     "mkdirp": "^0.5.0",
     "sort-object": "^1.0.0"


### PR DESCRIPTION
`1.1-this-is_dope` -> `1.1 This Is Dope`

This method is used to define the `name` property of materials and views, which is used in templating the menu and listing pages.