### PR TITLE
store material front-matter data with material item

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,12 +320,14 @@ var parseMaterials = function () {
 		if (!isSubCollection) {
 			assembly.materials[collection].items[key] = {
 				name: toTitleCase(id),
-				notes: (fileMatter.data.notes) ? md.render(fileMatter.data.notes) : ''
+				notes: (fileMatter.data.notes) ? md.render(fileMatter.data.notes) : '',
+				data: localData
 			};
 		} else {
 			assembly.materials[parent].items[collection].items[key] = {
 				name: toTitleCase(id.split('.')[1]),
-				notes: (fileMatter.data.notes) ? md.render(fileMatter.data.notes) : ''
+				notes: (fileMatter.data.notes) ? md.render(fileMatter.data.notes) : '',
+				data: localData
 			};
 		}
 


### PR DESCRIPTION
Store a material's front-matter data (excluding notes) in the templating context so that it can be accessed when iterating over the `materials.items` hash.

e.g.

```
---
foo: bar
---
```

```
{{#each items}}
  {{data.foo}}
{{/each}}
```