### PR TITLE
Optional page path setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,9 +242,9 @@ var buildContext = function (data) {
  * @return {String}
  */
 var toTitleCase = function(str) {
-    return str.replace(/(\-|_)/g, ' ').replace(/\w\S*/g, function(word) {
-        return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
-    });
+		return str.replace(/(\-|_)/g, ' ').replace(/\w\S*/g, function(word) {
+				return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
+		});
 };
 
 
@@ -614,15 +614,20 @@ var assemble = function () {
 			context = buildContext(pageMatter.data),
 			template = Handlebars.compile(source);
 
+		// redefine file path if dest front-matter variable is defined
+		if (pageMatter.data.dest) {
+			var filePath = path.normalize(pageMatter.data.dest);
+		}
+
 		// write file
 		mkdirp.sync(path.dirname(filePath));
 		fs.writeFileSync(filePath, template(context));
 
-		// write file if custom dest front-matter variable is defined
-		if (pageMatter.data.dest) {
-			var customPath = path.normalize(pageMatter.data.dest);
-			mkdirp.sync(path.dirname(customPath));
-			fs.writeFileSync(customPath, template(context));
+		// write a copy file if custom dest-copy front-matter variable is defined
+		if (pageMatter.data.dest-copy) {
+			var copyPath = path.normalize(pageMatter.data.dest-copy);
+			mkdirp.sync(path.dirname(copyPath));
+			fs.writeFileSync(copyPath, template(context));
 		}
 	});
 

--- a/index.js
+++ b/index.js
@@ -620,11 +620,10 @@ var assemble = function () {
 
 		// write file if custom dest front-matter variable is defined
 		if (pageMatter.data.dest) {
-				var customPath = path.normalize(pageMatter.data.dest);
-				mkdirp.sync(path.dirname(customPath));
-				fs.writeFileSync(customPath, template(context));
+			var customPath = path.normalize(pageMatter.data.dest);
+			mkdirp.sync(path.dirname(customPath));
+			fs.writeFileSync(customPath, template(context));
 		}
-
 	});
 
 };

--- a/index.js
+++ b/index.js
@@ -620,7 +620,9 @@ var assemble = function () {
 
 		// write file if custom dest front-matter variable is defined
 		if (pageMatter.data.dest) {
-			fs.writeFileSync(pageMatter.data.dest, template(context));
+				var customPath = path.normalize(pageMatter.data.dest);
+				mkdirp.sync(path.dirname(customPath));
+				fs.writeFileSync(customPath, template(context));
 		}
 
 	});

--- a/index.js
+++ b/index.js
@@ -242,9 +242,9 @@ var buildContext = function (data) {
  * @return {String}
  */
 var toTitleCase = function(str) {
-		return str.replace(/(\-|_)/g, ' ').replace(/\w\S*/g, function(word) {
-				return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
-		});
+	return str.replace(/(\-|_)/g, ' ').replace(/\w\S*/g, function(word) {
+		return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
+	});
 };
 
 

--- a/index.js
+++ b/index.js
@@ -616,7 +616,7 @@ var assemble = function () {
 
 		// redefine file path if dest front-matter variable is defined
 		if (pageMatter.data.dest) {
-			var filePath = path.normalize(pageMatter.data.dest);
+			filePath = path.normalize(pageMatter.data.dest);
 		}
 
 		// write file

--- a/index.js
+++ b/index.js
@@ -618,6 +618,11 @@ var assemble = function () {
 		mkdirp.sync(path.dirname(filePath));
 		fs.writeFileSync(filePath, template(context));
 
+		// write file if custom dest front-matter variable is defined
+		if (pageMatter.data.dest) {
+			fs.writeFileSync(pageMatter.data.dest, template(context));
+		}
+
 	});
 
 };

--- a/index.js
+++ b/index.js
@@ -624,8 +624,8 @@ var assemble = function () {
 		fs.writeFileSync(filePath, template(context));
 
 		// write a copy file if custom dest-copy front-matter variable is defined
-		if (pageMatter.data.dest-copy) {
-			var copyPath = path.normalize(pageMatter.data.dest-copy);
+		if (pageMatter.data['dest-copy']) {
+			var copyPath = path.normalize(pageMatter.data['dest-copy']);
 			mkdirp.sync(path.dirname(copyPath));
 			fs.writeFileSync(copyPath, template(context));
 		}


### PR DESCRIPTION
Can build a template also in a custom destination. For example in a Wordpress/Drupal theme or inside a framework dir structure. Discussed in [Fabricator issue](https://github.com/fbrctr/fabricator/issues/117).

A use `dest`, but we can rename it. What do you think ?

in template (base.html) : 

````html
---
dest: ./somewhere/over/the/rainbow.html
---
````

Sorry for not doing it sooner, I wasn't thinking that will be so simple :sweat_smile:
