### PR TITLE
Make hash values available in build context

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ var handleError = function (e) {
  * @param  {Object} data
  * @return {Object}
  */
-var buildContext = function (data) {
+var buildContext = function (data, hash) {
 
 	// set keys to whatever is defined
 	var materials = {};
@@ -231,7 +231,7 @@ var buildContext = function (data) {
 	var docs = {};
 	docs[options.keys.docs] = assembly.docs;
 
-	return _.assign({}, data, assembly.data, assembly.materialData, materials, views, docs);
+	return _.assign({}, data, assembly.data, assembly.materialData, materials, views, docs, hash);
 
 };
 
@@ -534,7 +534,7 @@ var registerHelpers = function () {
 	 * @example
 	 * {{material name context}}
 	 */
-	Handlebars.registerHelper(inflect.singularize(options.keys.materials), function (name, context) {
+	Handlebars.registerHelper(inflect.singularize(options.keys.materials), function (name, context, options) {
 
 		// remove leading numbers from name keyword
 		// partials are always registered with the leading numbers removed
@@ -552,7 +552,7 @@ var registerHelpers = function () {
 		}
 
 		// return beautified html with trailing whitespace removed
-		return beautifyHtml(fn(buildContext(context)).replace(/^\s+/, ''), options.beautifier);
+		return beautifyHtml(fn(buildContext(context, options.hash)).replace(/^\s+/, ''), options.beautifier);
 
 	});
 


### PR DESCRIPTION
This tiny change makes Fabricator more powerful. For example if I create material for a button element like this:
```
<button class="btn{{#if class}} {{class}}{{/if}}">Button</button>
```
I can then use the button helper like this `{{> button}}` to get a standard button:
```
<button class="btn">Button</button>
```
Or like this `{{> button class="btn-sm"}}` to add a class `btn-sm` and I will get this:
```
<button class="btn">Button</button>
```
This can be useful for adding more than just classes to helpers. The posibilities depend on how complex you want to make materials. But there are lots of sumple use cases.

This paragraph helper will accept an optional content attribute:
```
{{#if content}}
  <p>{{content}}</p>
{{/if}}
{{#unless content}}
  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam a mi massa....</p>
{{/unless}}
```
Usage:  `{{> paragraph content="This is a short sentence."}}` will result in:
```
<p>This is a short sentence.</p>
```