### PR TITLE
fix dir glob pattern.

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,10 @@ var parseMaterials = function () {
 	var files = globby.sync(options.materials, { nodir: true, nosort: true });
 
 	// build a glob for identifying directories
-	var dirsGlob = path.dirname(options.materials) + '/*/';
+	options.materials = (typeof options.materials === 'string') ? [options.materials] : options.materials;
+	var dirsGlob = options.materials.map(function (pattern) {
+		return path.dirname(pattern) + '/*/';
+	});
 
 	// get all directories
 	// do a new glob; trailing slash matches only dirs

--- a/index.js
+++ b/index.js
@@ -270,9 +270,12 @@ var parseMaterials = function () {
 	// get files and dirs
 	var files = globby.sync(options.materials, { nodir: true, nosort: true });
 
+	// build a glob for identifying directories
+	var dirsGlob = path.dirname(options.materials) + '/*/';
+
 	// get all directories
 	// do a new glob; trailing slash matches only dirs
-	var dirs = globby.sync(options.materials + '/').map(function (dir) {
+	var dirs = globby.sync(dirsGlob).map(function (dir) {
 		return path.normalize(dir).split(path.sep).slice(-2, -1)[0];
 	});
 


### PR DESCRIPTION
this allows users to define extensions in their glob pattern without breaking the grouping functionality.

fixes #23 