### PR TITLE
Allow Handlebars instance to be passed in as an option

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,8 +160,10 @@ var assembly = {
  * @return {String}
  */
 var getName = function (filePath, preserveNumbers) {
-	var name = path.basename(filePath, path.extname(filePath));
+	// get name; replace spaces with dashes
+	var name = path.basename(filePath, path.extname(filePath)).replace(/\s/g, '-');
 	return (preserveNumbers) ? name : name.replace(/^[0-9|\.\-]+/, '');
+
 };
 
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var beautifyHtml = require('js-beautify').html;
 var chalk = require('chalk');
 var fs = require('fs');
 var globby = require('globby');
-var Handlebars = require('handlebars');
 var inflect = require('i')();
 var matter = require('gray-matter');
 var md = require('markdown-it')({ html: true, linkify: true });
@@ -12,6 +11,7 @@ var mkdirp = require('mkdirp');
 var path = require('path');
 var sortObj = require('sort-object');
 var yaml = require('js-yaml');
+var Handlebars;
 
 
 /**
@@ -97,7 +97,12 @@ var defaults = {
 	 * Whether or not to log errors to console
 	 * @type {Boolean}
 	 */
-	logErrors: false
+	logErrors: false,
+
+    /**
+     * Handlebars instance to use
+     */
+    handlebars: require('handlebars')
 };
 
 
@@ -580,6 +585,9 @@ var setup = function (userOptions) {
 
 	// merge user options with defaults
 	options = _.merge({}, defaults, userOptions);
+
+    // set Handlebars reference used by multiple functions below
+    Handlebars = options.handlebars;
 
 	// setup steps
 	registerHelpers();

--- a/package.json
+++ b/package.json
@@ -18,19 +18,19 @@
   "repository": "fbrctr/fabricator-assemble",
   "dependencies": {
     "chalk": "^1.0.0",
-    "globby": "^2.0.0",
-    "gray-matter": "^2.0.0",
+    "globby": "^2.1.0",
+    "gray-matter": "^2.0.1",
     "handlebars": "^3.0.3",
     "i": "^0.3.3",
-    "js-beautify": "^1.5.5",
-    "js-yaml": "^3.2.7",
-    "lodash": "^3.8.0",
-    "markdown-it": "^4.2.1",
+    "js-beautify": "^1.5.10",
+    "js-yaml": "^3.4.0",
+    "lodash": "^3.10.1",
+    "markdown-it": "^4.4.0",
     "mkdirp": "^0.5.0",
     "sort-object": "^1.0.0"
   },
   "devDependencies": {
-    "del": "^1.1.1",
+    "del": "^2.0.1",
     "helper-markdown": "^0.1.1",
     "html-minifier": "^0.7.2",
     "mocha": "^2.1.0"


### PR DESCRIPTION
This change allows the Handlebars instance to be overwritten by passing a `handlebars` option. 

The ability to optionally supply the instance provides greater flexibility when the instance must be shared with other libraries. For example:

```js
import assemble from 'fabricator-assemble';
import gulp from 'gulp';
import Handlebars from 'handlebars';
import handlebarsLayouts from 'handlebars-layouts';

// Register layout helpers
handlebarsLayouts.register(Handlebars);

// Use those helpers with other helpers passed to Fabricator
gulp.task('assemble', function () {
  return assemble({
    handlebars: Handlebars,
    helpers: { /*...*/ }
  });
});
```