### PR TITLE
Grouping and ordering materials now work together

### DIFF
--- a/index.js
+++ b/index.js
@@ -552,7 +552,7 @@ var registerHelpers = function () {
 		// remove leading numbers from name keyword
 		// partials are always registered with the leading numbers removed
 		// This is for both the subCollection as the file(name) itself!
-		var key = name.replace(/(\d+[\-\.])+/, '').replace(/[\.](\d+[\-\.])+/, '.');
+		var key = name.replace(/(\d+[\-\.])+/, '').replace(/(\d+[\-\.])+/, '');
 
 		// attempt to find pre-compiled partial
 		var template = Handlebars.partials[key],

--- a/index.js
+++ b/index.js
@@ -551,7 +551,8 @@ var registerHelpers = function () {
 
 		// remove leading numbers from name keyword
 		// partials are always registered with the leading numbers removed
-		var key = name.replace(/(\d+[\-\.])+/, '');
+		// This is for both the subCollection as the file(name) itself!
+		var key = name.replace(/(\d+[\-\.])+/, '').replace(/[\.](\d+[\-\.])+/, '.');
 
 		// attempt to find pre-compiled partial
 		var template = Handlebars.partials[key],


### PR DESCRIPTION
Ordering materials and grouping them are two different feature of the assembler, but they don't really work together. Grouping or not, you can only order the first level. I fixed it so that you can group both levels, the groups and the actual items in the groups.