### PR TITLE
Added config options for output extension and destination map

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,12 @@ var defaults = {
 	data: ['src/data/**/*.{json,yml}'],
 
 	/**
+	 * Data to be merged into context
+	 * @type {(Object)}
+	 */
+	buildData: {},
+
+	/**
 	 * Markdown files containing toolkit-wide documentation
 	 * @type {(String|Array)}
 	 */
@@ -245,7 +251,7 @@ var buildContext = function (data, hash) {
 	var docs = {};
 	docs[options.keys.docs] = assembly.docs;
 
-	return _.assign({}, data, assembly.data, assembly.materialData, materials, views, docs, hash);
+	return _.assign({}, data, assembly.data, assembly.materialData, options.buildData, materials, views, docs, hash);
 
 };
 

--- a/index.js
+++ b/index.js
@@ -84,6 +84,12 @@ var defaults = {
   extension: '.html',
 
 	/**
+	 * Custom dest map
+	 * @type {Object}
+	 */
+  destMap: {},
+
+	/**
 	 * beautifier options
 	 * @type {Object}
 	 */
@@ -638,6 +644,10 @@ var assemble = function () {
 		if (pageMatter.data.dest) {
 			filePath = path.normalize(pageMatter.data.dest);
 		}
+
+    if (options.destMap[collection]) {
+			filePath = path.normalize(path.join(options.destMap[collection], path.basename(file)));
+    }
 
 		// change extension to .html
 		filePath = filePath.replace(/\.[0-9a-z]+$/, options.extension);

--- a/index.js
+++ b/index.js
@@ -83,6 +83,12 @@ var defaults = {
 	 */
   extension: '.html',
 
+  /**
+	 * Output pages to partials
+	 * @type {Boolean}
+	 */
+   partials: false,
+
 	/**
 	 * beautifier options
 	 * @type {Object}
@@ -630,7 +636,7 @@ var assemble = function () {
 		}
 
 		// template using Handlebars
-		var source = wrapPage(pageContent, assembly.layouts[pageMatter.data.layout || options.layout]),
+		var source = (options.partials) ? pageContent : wrapPage(pageContent, assembly.layouts[pageMatter.data.layout || options.layout]),
 			context = buildContext(pageMatter.data),
 			template = Handlebars.compile(source);
 

--- a/index.js
+++ b/index.js
@@ -83,12 +83,6 @@ var defaults = {
 	 */
   extension: '.html',
 
-  /**
-	 * Output pages to partials
-	 * @type {Boolean}
-	 */
-   partials: false,
-
 	/**
 	 * beautifier options
 	 * @type {Object}
@@ -636,7 +630,7 @@ var assemble = function () {
 		}
 
 		// template using Handlebars
-		var source = (options.partials) ? pageContent : wrapPage(pageContent, assembly.layouts[pageMatter.data.layout || options.layout]),
+		var source = wrapPage(pageContent, assembly.layouts[pageMatter.data.layout || options.layout]),
 			context = buildContext(pageMatter.data),
 			template = Handlebars.compile(source);
 

--- a/index.js
+++ b/index.js
@@ -78,6 +78,12 @@ var defaults = {
 	dest: 'dist',
 
 	/**
+	 * Extension to output files as
+	 * @type {String}
+	 */
+  extension: '.html',
+
+	/**
 	 * beautifier options
 	 * @type {Object}
 	 */
@@ -634,7 +640,7 @@ var assemble = function () {
 		}
 
 		// change extension to .html
-		filePath = filePath.replace(/\.[0-9a-z]+$/, '.html');
+		filePath = filePath.replace(/\.[0-9a-z]+$/, options.extension);
 
 		// write file
 		mkdirp.sync(path.dirname(filePath));


### PR DESCRIPTION
I've added 2 options to the userConfig.
options.extension is used in place of '.html' when outputting pages
options.destMap is used when defined to change the output directory of specific collections.

I've used this in a .net project to output page content with a layout file that uses razor syntax and outputs to the views folder of the project.