### PR TITLE
Adding baseUrl config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Default options:
 	helpers: {},
 	logErrors: false,
 	onError: function(error) {},
-	dest: 'dist'
+	dest: 'dist',
+	baseUrl: '',
 }
 ```
 
@@ -207,6 +208,13 @@ Type: `String`
 Default: `dist`
 
 Destination of compiled views (where files are saved to)
+
+### options.baseUrl
+
+Type: `String`  
+Default: `''`
+
+Changes the baseurl path. Useful in build that require better path definitions for assets (ie: production builds).
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -115,7 +115,13 @@ var defaults = {
 	 * Whether or not to log errors to console
 	 * @type {Boolean}
 	 */
-	logErrors: false
+	logErrors: false,
+
+	/**
+	 * Overrides default when a value is given
+	 * @type {String}
+	 */
+	baseUrl: '',
 };
 
 
@@ -639,6 +645,10 @@ var assemble = function () {
 
 		if (collection) {
 			pageMatter.data.baseurl = '..';
+		}
+
+		if(options.baseUrl && options.baseUrl.length > 0) {
+			pageMatter.data.baseurl = options.baseUrl;
 		}
 
 		// template using Handlebars

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabricator-assemble",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "The assembly engine behind Fabricator",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Gives the user an option to define a baseUrl themselves this can help with building to an environment that isn't a local fabricator instance such as:

- B2C blob storage
- Packaging a build to be updated to a server
- Any other instances where setting the default baseUrl could be useful.
- Bumping to minor version 1.3.0