### PR TITLE
Adding GLOBAL option to the fabricator instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,19 @@ Default: `''`
 
 Changes the baseurl path. Useful in build that require better path definitions for assets (ie: production builds).
 
+### options.GLOBAL
+
+Type: `Object`
+Default: `{}`
+
+Sets up global values across your fabircator instance. Global values can be accessed by their keys.
+
+For example:
+
+`{{ GLOBAL.SIGN_IN_LINK }}`
+
+Globals in fabricator work in a similar manner to Webpacks DefinePlugin.
+
 ## Usage
 
 ### Definitions

--- a/index.js
+++ b/index.js
@@ -122,6 +122,19 @@ var defaults = {
 	 * @type {String}
 	 */
 	baseUrl: '',
+
+	/**
+	 * Sets up global values across your fabircator instance.
+	 * Global values can be accessed by their keys.
+	 * 
+	 * For example:
+	 * 
+	 * {{ GLOBAL.SIGN_IN_LINK }}
+	 * 
+	 * Globals in fabricator work in a similar manner to
+	 * webpacks DefinePlugin.
+	 */
+	GLOBAL: {},
 };
 
 
@@ -650,6 +663,8 @@ var assemble = function () {
 		if(options.baseUrl && options.baseUrl.length > 0) {
 			pageMatter.data.baseurl = options.baseUrl;
 		}
+
+		pageMatter.data.GLOBAL = options.GLOBAL;
 
 		// template using Handlebars
 		var source = wrapPage(pageContent, assembly.layouts[pageMatter.data.layout || options.layout]),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabricator-assemble",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "The assembly engine behind Fabricator",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Submitting this PR in order to leverage the following:

- Adding global values would allow users to include these [global] values in the same way Webpack users can with the DefinePlugin.
- If deploying to multiple environments, using global values prevents the need to change links locally and deploy those changes to the desired environment. This would be similar to how env vars work.